### PR TITLE
Using current task collection when adding new pages.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -27,6 +27,7 @@ var Paginator = require('./paginator');
 var filter = require('./util/filter');
 var pattern = require('./util/pattern');
 var process = require('./util/process');
+var getName = require('./util/get-name');
 
 /**
  * Plugin function for the generation of index templates.
@@ -38,8 +39,9 @@ var process = require('./util/process');
 function index(key, options) {
   // jshint validthis:true
   var assemble = this;
+  var plural = getName(assemble);
 
-  // buidl options object
+  // build options object
   options = extend({limit: 10}, assemble.option('index'), options);
 
   // Get the template that was defined by the user in the options
@@ -95,8 +97,7 @@ function index(key, options) {
 
       paginator.pages.forEach(function(page) {
         // add to pages collection
-        var key = renameKey(page.path);
-        assemble.views.pages[key] = page;
+        assemble[plural](page);
 
         // push into stream
         that.push(tutils.toVinyl(page));

--- a/lib/util/get-name.js
+++ b/lib/util/get-name.js
@@ -1,0 +1,12 @@
+'use strict';
+
+module.exports = function (assemble) {
+  var session = assemble.session;
+  var taskName = session.get('task name');
+  var templateType = 'page';
+  if (taskName) {
+    templateType = '__task__' + taskName;
+  }
+  var plural = assemble.collection[templateType];
+  return plural;
+}

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
   "engines": {
     "node": ">= 0.8.0"
   },
+  "scripts": {
+    "test": "mocha -R spec"
+  },
   "dependencies": {
     "arr-diff": "^1.0.1",
     "clone-deep": "^0.1.1",
@@ -37,7 +40,8 @@
   },
   "devDependencies": {
     "grunt": "^0.4.5",
-    "grunt-contrib-jshint": "~0.10.0"
+    "grunt-contrib-jshint": "~0.10.0",
+    "gulp-extname": "^0.2.0"
   },
   "keywords": [
     "assemble",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
     }
   ],
   "main": "index.js",
+  "files": [
+    "index.js",
+    "lib/"
+  ],
   "engines": {
     "node": ">= 0.8.0"
   },

--- a/test/actual/dest/about.html
+++ b/test/actual/dest/about.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>About Page</title>
+  <link rel="stylesheet" href="./assets/css/site.css">
+</head>
+<body>
+  <div>About Page</div>
+
+</body>
+</html>

--- a/test/actual/dest/home.html
+++ b/test/actual/dest/home.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Home Page</title>
+  <link rel="stylesheet" href="./assets/css/site.css">
+</head>
+<body>
+  <div>Home Page</div>
+
+</body>
+</html>

--- a/test/actual/dest/index.html
+++ b/test/actual/dest/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title></title>
+  <link rel="stylesheet" href="./assets/css/site.css">
+</head>
+<body>
+  <ul>
+    <li><a href="about.html">About Page</a></li>
+    <li><a href="home.html">Home Page</a></li>
+    <li><a href="post-1.html">Post One</a></li>
+    <li><a href="post-10.html">Post Ten</a></li>
+    <li><a href="post-2.html">Post Two</a></li>
+    <li><a href="post-3.html">Post Three</a></li>
+    <li><a href="post-4.html">Post Four</a></li>
+    <li><a href="post-5.html">Post Five</a></li>
+    <li><a href="post-6.html">Post Six</a></li>
+    <li><a href="post-7.html">Post Seven</a></li>
+</ul>
+  <ul>
+      <li><a>Prev</a></li>
+        <li><a>0</a></li>
+        <li><a href="index1.hbs">1</a></li>
+      <li><a href="">Next</a></li>
+  </ul>
+</body>
+</html>

--- a/test/actual/dest/index1.html
+++ b/test/actual/dest/index1.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title></title>
+  <link rel="stylesheet" href="./assets/css/site.css">
+</head>
+<body>
+  <ul>
+    <li><a href="post-8.html">Post Eight</a></li>
+    <li><a href="post-9.html">Post Nine</a></li>
+</ul>
+  <ul>
+      <li><a href="index.hbs">Prev</a></li>
+        <li><a href="index.hbs">0</a></li>
+        <li><a>1</a></li>
+      <li><a>Next</a></li>
+  </ul>
+</body>
+</html>

--- a/test/actual/dest/post-1.html
+++ b/test/actual/dest/post-1.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Post One</title>
+  <link rel="stylesheet" href="./assets/css/site.css">
+</head>
+<body>
+  <div>Post One</div>
+
+</body>
+</html>

--- a/test/actual/dest/post-10.html
+++ b/test/actual/dest/post-10.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Post Ten</title>
+  <link rel="stylesheet" href="./assets/css/site.css">
+</head>
+<body>
+  <div>Post Ten</div>
+
+</body>
+</html>

--- a/test/actual/dest/post-2.html
+++ b/test/actual/dest/post-2.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Post Two</title>
+  <link rel="stylesheet" href="./assets/css/site.css">
+</head>
+<body>
+  <div>Post Two</div>
+
+</body>
+</html>

--- a/test/actual/dest/post-3.html
+++ b/test/actual/dest/post-3.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Post Three</title>
+  <link rel="stylesheet" href="./assets/css/site.css">
+</head>
+<body>
+  <div>Post Three</div>
+
+</body>
+</html>

--- a/test/actual/dest/post-4.html
+++ b/test/actual/dest/post-4.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Post Four</title>
+  <link rel="stylesheet" href="./assets/css/site.css">
+</head>
+<body>
+  <div>Post Four</div>
+
+</body>
+</html>

--- a/test/actual/dest/post-5.html
+++ b/test/actual/dest/post-5.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Post Five</title>
+  <link rel="stylesheet" href="./assets/css/site.css">
+</head>
+<body>
+  <div>Post Five</div>
+
+</body>
+</html>

--- a/test/actual/dest/post-6.html
+++ b/test/actual/dest/post-6.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Post Six</title>
+  <link rel="stylesheet" href="./assets/css/site.css">
+</head>
+<body>
+  <div>Post Six</div>
+
+</body>
+</html>

--- a/test/actual/dest/post-7.html
+++ b/test/actual/dest/post-7.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Post Seven</title>
+  <link rel="stylesheet" href="./assets/css/site.css">
+</head>
+<body>
+  <div>Post Seven</div>
+
+</body>
+</html>

--- a/test/actual/dest/post-8.html
+++ b/test/actual/dest/post-8.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Post Eight</title>
+  <link rel="stylesheet" href="./assets/css/site.css">
+</head>
+<body>
+  <div>Post Eight</div>
+
+</body>
+</html>

--- a/test/actual/dest/post-9.html
+++ b/test/actual/dest/post-9.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Post Nine</title>
+  <link rel="stylesheet" href="./assets/css/site.css">
+</head>
+<body>
+  <div>Post Nine</div>
+
+</body>
+</html>

--- a/test/fixtures/indices/index.hbs
+++ b/test/fixtures/indices/index.hbs
@@ -1,0 +1,26 @@
+<ul>
+  {{#each items}}
+    <li><a href="{{url}}">{{title}}</a></li>
+  {{/each}}
+</ul>
+{{#with pagination}}
+  <ul>
+    {{#if isFirst}}
+      <li><a>Prev</a></li>
+    {{else}}
+      <li><a href="{{prev}}">Prev</a></li>
+    {{/if}}
+    {{#each pages}}
+      {{#is this ../current}}
+        <li><a>{{@index}}</a></li>
+      {{else}}
+        <li><a href="{{this}}">{{@index}}</a></li>
+      {{/is}}
+    {{/each}}
+    {{#if isLast}}
+      <li><a>Next</a></li>
+    {{else}}
+      <li><a href="{{last}}">Next</a></li>
+    {{/if}}
+  </ul>
+{{/with}}

--- a/test/fixtures/layouts/default.hbs
+++ b/test/fixtures/layouts/default.hbs
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>{{title}}</title>
+  <link rel="stylesheet" href="{{assets}}/css/site.css">
+</head>
+<body>
+  {% body %}
+</body>
+</html>

--- a/test/fixtures/pages/about.hbs
+++ b/test/fixtures/pages/about.hbs
@@ -1,0 +1,4 @@
+---
+title: About Page
+---
+<div>{{title}}</div>

--- a/test/fixtures/pages/home.hbs
+++ b/test/fixtures/pages/home.hbs
@@ -1,0 +1,4 @@
+---
+title: Home Page
+---
+<div>{{title}}</div>

--- a/test/fixtures/pages/post-1.hbs
+++ b/test/fixtures/pages/post-1.hbs
@@ -1,0 +1,4 @@
+---
+title: Post One
+---
+<div>{{title}}</div>

--- a/test/fixtures/pages/post-10.hbs
+++ b/test/fixtures/pages/post-10.hbs
@@ -1,0 +1,4 @@
+---
+title: Post Ten
+---
+<div>{{title}}</div>

--- a/test/fixtures/pages/post-2.hbs
+++ b/test/fixtures/pages/post-2.hbs
@@ -1,0 +1,4 @@
+---
+title: Post Two
+---
+<div>{{title}}</div>

--- a/test/fixtures/pages/post-3.hbs
+++ b/test/fixtures/pages/post-3.hbs
@@ -1,0 +1,4 @@
+---
+title: Post Three
+---
+<div>{{title}}</div>

--- a/test/fixtures/pages/post-4.hbs
+++ b/test/fixtures/pages/post-4.hbs
@@ -1,0 +1,4 @@
+---
+title: Post Four
+---
+<div>{{title}}</div>

--- a/test/fixtures/pages/post-5.hbs
+++ b/test/fixtures/pages/post-5.hbs
@@ -1,0 +1,4 @@
+---
+title: Post Five
+---
+<div>{{title}}</div>

--- a/test/fixtures/pages/post-6.hbs
+++ b/test/fixtures/pages/post-6.hbs
@@ -1,0 +1,4 @@
+---
+title: Post Six
+---
+<div>{{title}}</div>

--- a/test/fixtures/pages/post-7.hbs
+++ b/test/fixtures/pages/post-7.hbs
@@ -1,0 +1,4 @@
+---
+title: Post Seven
+---
+<div>{{title}}</div>

--- a/test/fixtures/pages/post-8.hbs
+++ b/test/fixtures/pages/post-8.hbs
@@ -1,0 +1,4 @@
+---
+title: Post Eight
+---
+<div>{{title}}</div>

--- a/test/fixtures/pages/post-9.hbs
+++ b/test/fixtures/pages/post-9.hbs
@@ -1,0 +1,4 @@
+---
+title: Post Nine
+---
+<div>{{title}}</div>

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,46 @@
+'use strict';
+
+var extname = require('gulp-extname');
+var assemble = require('assemble');
+var assert = require('assert');
+
+var Index = require('../');
+
+describe('assemble-plugin-index', function () {
+  var inst = null;
+  var index = null;
+  beforeEach(function () {
+    inst = assemble.init();
+    index = Index(inst);
+  });
+
+  it('should add new pages to the correct collection', function (done) {
+    var renameKey = inst.option('renameKey');
+
+    inst.option('layout', 'default');
+    inst.option('assets', 'test/actual/dest/assets');
+
+    inst.layouts(['test/fixtures/layouts/*.hbs']);
+    inst.indices(['test/fixtures/indices/*.hbs']);
+
+    inst.task('test', function () {
+      return inst.src('test/fixtures/pages/*.hbs')
+        .pipe(index('index', { filter: ['title'] }))
+        .on('data', function (file) {
+          var key = renameKey(file.path);
+          assert.equal(inst.views['__task__tests'][key].path, file.path);
+          assert.equal(inst.files[key].path, file.path);
+        })
+        .on('end', function () {
+          assert(inst.views['__task__tests'].hasOwnProperty('index'));
+          assert(inst.views['__task__tests'].hasOwnProperty('index1'));
+          assert(inst.files.hasOwnProperty('index'));
+          assert(inst.files.hasOwnProperty('index1'));
+        })
+        .pipe(extname())
+        .pipe(inst.dest('test/actual/dest'));
+    });
+    inst.task('default', ['test'], function () { done(); });
+    inst.run('default');
+  });
+});


### PR DESCRIPTION
This PR includes a new method that gets the current task name from the session to be able to add the new pages to the correct view collection.

It also adds some tests that include `{{assets}}` and usage in the layout.

We're currently updating a few things in assemble to expose methods to get the task name information more easily, but they aren't finished yet.

There's also an error if you add `assemble@beta` to `devDependencies` because of a version mismatch in `template-utils`. The tests will run through if you have `assemble@beta` installed globally. I'll see about getting some of the dependencies updated so this doesn't happen.
